### PR TITLE
必ず落ちるテストを削除した

### DIFF
--- a/spec/esa_feeder_spec.rb
+++ b/spec/esa_feeder_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe EsaFeeder do
   it "has a version number" do
     expect(EsaFeeder::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
デフォルトで生成されているが、CIを仕込むのに邪魔なので削除する。