### PR TITLE
UseCaseのテストを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,3 @@ gem 'esa'
 gem 'pry'
 gem 'thor'
 gem 'slack-notifier'
-
-group :development, :test do
-  gem 'timecop'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,6 @@ GEM
     rspec-support (3.7.0)
     slack-notifier (2.3.1)
     thor (0.20.0)
-    timecop (0.9.1)
 
 PLATFORMS
   ruby
@@ -52,7 +51,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   slack-notifier
   thor
-  timecop
 
 BUNDLED WITH
    1.15.4

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -1,8 +1,7 @@
 require "spec_helper"
-require "timecop"
 
 RSpec.describe EsaFeeder::UseCases::Feed do
-  let(:monday) { Time.local(2017, 10, 23) }
+  let(:monday) {Time.local(2017, 10, 23)}
 
   let(:esa_client) {double('esa client')}
   let(:slack_client) {double('slack client')}
@@ -31,22 +30,18 @@ RSpec.describe EsaFeeder::UseCases::Feed do
 
   context 'default' do
     it 'called on Monday' do
-      Timecop.travel(monday) do
-        expect(esa_client).to receive(:find_templates).with('feed_mon').once
-        expect(esa_client).to receive(:create_from_template).with(templates[0], 'esa_bot').once
-        expect(esa_client).to receive(:create_from_template).with(templates[1], 'esa_bot').once
-        expect(slack_client).to receive(:notify_creation).exactly(templates.count)
-        expect(described_class.new(esa_client, slack_client).call).to eq([{1 => 101}, {2 => 102}])
-      end
+      expect(esa_client).to receive(:find_templates).with('feed_mon').once
+      expect(esa_client).to receive(:create_from_template).with(templates[0], 'esa_bot').once
+      expect(esa_client).to receive(:create_from_template).with(templates[1], 'esa_bot').once
+      expect(slack_client).to receive(:notify_creation).exactly(templates.count)
+      expect(described_class.new(esa_client, slack_client).call(time: monday)).to eq([{1 => 101}, {2 => 102}])
     end
   end
 
   context 'slack notifier is empty' do
     it 'notify_creation not called' do
-      Timecop.travel(monday) do
-        expect(slack_client).not_to receive(:notify_creation)
-        expect(described_class.new(esa_client, nil).call).to eq([{1 => 101}, {2 => 102}])
-      end
+      expect(slack_client).not_to receive(:notify_creation)
+      expect(described_class.new(esa_client, nil).call(time: monday)).to eq([{1 => 101}, {2 => 102}])
     end
   end
 end


### PR DESCRIPTION
UseCases::Feedのテストを書きます。

 - 引数無しで正しく各種メソッドがコールされること
 - time, userを指定した時に正しく動作する
 - slack notifierがnilのときは通知がコールされないこと
 - callの返り値で、template.number => post.number の配列が返ること

モックしまくりつらい