### PR TITLE
Herokuでロゴ画像が正しく表示されるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ vi .env
 
 以下のボタンから[Heroku](https://dashboard.heroku.com/)にデプロイできます。
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/standfirm/esa_feeder/)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 
 環境変数については、esaのチーム名とアクセストークンが指定必須です。  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EsaFeeder
 
-[![CircleCI](https://circleci.com/gh/standfirm/esa_feeder.svg?style=svg&circle-token=b211037d0e100aae7eca4acea088966f26a71275)](https://circleci.com/gh/standfirm/esa_feeder)
+[![CircleCI](https://circleci.com/gh/standfirm/esa_feeder.svg?style=svg)](https://circleci.com/gh/standfirm/esa_feeder)
 
 [esa.io](https://esa.io/) のテンプレートから定期的に記事を自動作成するツールです。
 

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "esa feeder",
   "description": "periodic post generator for esa.io",
   "repository": "https://github.com/standfirm/esa_feeder",
-  "logo": "https://raw.githubusercontent.com/standfirm/master/heroku-button/logo.png",
+  "logo": "https://raw.githubusercontent.com/standfirm/esa_feeder/master/logo.png",
   "keywords": ["ruby", "esa.io"],
   "env": {
     "ESA_TEAM": {


### PR DESCRIPTION
ロゴ画像のURLが間違っていたため修正する。
また合わせてpublicリポジトリでは不要になる設定をいくつか削除した。