### PR TITLE
通知先のSlack Channelを指定できるようにする

### DIFF
--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -2,7 +2,6 @@ module EsaFeeder
   module Entities
     class EsaPost < Struct.new(:number, :full_name, :url, :tags)
       def slack_channels
-        return nil if tags.nil?
         tags.select { |tag| tag=~ /^slack_/ }.map { |tag| tag.gsub(/^slack_/, '') }
       end
     end

--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -3,7 +3,7 @@ module EsaFeeder
     class EsaPost < Struct.new(:number, :full_name, :url, :tags)
       def slack_channels
         return nil if tags.nil?
-        tags.select { |tag| tag=~ /slack_/ }.map { |tag| tag.gsub(/slack_/, '') }
+        tags.select { |tag| tag=~ /^slack_/ }.map { |tag| tag.gsub(/^slack_/, '') }
       end
     end
   end

--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -1,5 +1,10 @@
 module EsaFeeder
   module Entities
-    EsaPost = Struct.new(:number, :full_name, :url)
+    class EsaPost < Struct.new(:number, :full_name, :url, :tags)
+      def slack_channels
+        return nil if tags.nil?
+        tags.select { |tag| tag=~ /slack_/ }.map { |tag| tag.gsub(/slack_/, '') }
+      end
+    end
   end
 end

--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -29,7 +29,8 @@ module EsaFeeder
         Entities::EsaPost.new(
           raw['number'],
           raw['full_name'],
-          raw['url']
+          raw['url'],
+          raw['tags']
         )
       end
     end

--- a/lib/esa_feeder/gateways/slack_client.rb
+++ b/lib/esa_feeder/gateways/slack_client.rb
@@ -9,11 +9,12 @@ module EsaFeeder
 
       def notify_creation(message, post)
         driver.post attachments: [{
-          pretext: message,
-          title: post.full_name,
-          title_link: post.url,
-          color: 'good'
-        }]
+                                    pretext: message,
+                                    title: post.full_name,
+                                    title_link: post.url,
+                                    color: 'good'
+                                  }],
+                    channel: post.slack_channels
       end
 
       private

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -1,14 +1,14 @@
 require "spec_helper"
 
 RSpec.describe EsaFeeder::Entities::EsaPost do
-  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo']) }
+  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo', 'hoge_slack_foo']) }
   let(:post_no_tag) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999') }
 
   it 'can assign values' do
     expect(post.number).to eq(99999)
     expect(post.full_name).to eq('path/to/post/post_title #tag')
     expect(post.url).to eq('https://example.com/posts/99999')
-    expect(post.tags).to eq(['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo'])
+    expect(post.tags).to eq(['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo', 'hoge_slack_foo'])
   end
 
   describe '#slack_channels' do

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -1,11 +1,29 @@
 require "spec_helper"
 
 RSpec.describe EsaFeeder::Entities::EsaPost do
-  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999') }
+  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo']) }
+  let(:post_no_tag) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999') }
 
   it 'can assign values' do
     expect(post.number).to eq(99999)
     expect(post.full_name).to eq('path/to/post/post_title #tag')
     expect(post.url).to eq('https://example.com/posts/99999')
+    expect(post.tags).to eq(['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo'])
+  end
+
+  describe '#slack_channels' do
+    context 'with tags' do
+      subject { post.slack_channels }
+      it 'return only slack tag' do
+        expect(subject).to eq(['hoge', 'foo'])
+      end
+    end
+
+    context 'with no tags' do
+      subject { post_no_tag.slack_channels }
+      it 'return empty array' do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -1,28 +1,28 @@
 require "spec_helper"
 
 RSpec.describe EsaFeeder::Entities::EsaPost do
-  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo', 'hoge_slack_foo']) }
-  let(:post_no_tag) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999') }
+  let(:post) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'feed_tue']) }
+  let(:post_with_slack_tag) { described_class.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999', ['feed_mon', 'slack_hoge', 'hoge_slack_foo', 'slack_foo']) }
 
   it 'can assign values' do
     expect(post.number).to eq(99999)
     expect(post.full_name).to eq('path/to/post/post_title #tag')
     expect(post.url).to eq('https://example.com/posts/99999')
-    expect(post.tags).to eq(['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo', 'hoge_slack_foo'])
+    expect(post.tags).to eq(['feed_mon', 'feed_tue'])
   end
 
   describe '#slack_channels' do
-    context 'with tags' do
-      subject { post.slack_channels }
+    context 'with slack tags' do
+      subject { post_with_slack_tag.slack_channels }
       it 'return only slack tag' do
         expect(subject).to eq(['hoge', 'foo'])
       end
     end
 
-    context 'with no tags' do
-      subject { post_no_tag.slack_channels }
+    context 'with no slack tags' do
+      subject { post.slack_channels }
       it 'return empty array' do
-        expect(subject).to be_nil
+        expect(subject).to eq([])
       end
     end
   end

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -6,16 +6,18 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
   let(:template) {
     EsaFeeder::Entities::EsaPost.new(
       99999,
-      'templates/category/test #feed_mon',
-      'https://example.com/posts/99999'
+      'templates/category/test #feed_mon #slack_hoge',
+      'https://example.com/posts/99999',
+      ['feed_mon', 'slack_hoge']
     ) }
 
   describe '#find_templates' do
     let(:body) do
       { 'posts' => [
         'number' => 99999,
-        'full_name' => 'templates/category/test #feed_mon',
-        'url' => 'https://example.com/posts/99999'
+        'full_name' => 'templates/category/test #feed_mon #slack_hoge',
+        'url' => 'https://example.com/posts/99999',
+        'tags' => ['feed_mon', 'slack_hoge']
       ]}
     end
     let(:response) { double('response', body: body) }
@@ -33,14 +35,16 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     let(:body) do
       { 'number' => 12345,
         'full_name' => 'category/test #feed_mon',
-        'url' => 'https://example.com/posts/12345' }
+        'url' => 'https://example.com/posts/12345',
+        'tags' => ['feed_mon'] }
     end
     let(:response) { double('response', body: body) }
     let(:post) {
       EsaFeeder::Entities::EsaPost.new(
         12345,
         'category/test #feed_mon',
-        'https://example.com/posts/12345'
+        'https://example.com/posts/12345',
+        ['feed_mon']
       ) }
 
     subject { target.create_from_template(template, 'bot_user') }

--- a/spec/gateways/slack_client_spec.rb
+++ b/spec/gateways/slack_client_spec.rb
@@ -1,7 +1,11 @@
 require "spec_helper"
 
 RSpec.describe EsaFeeder::Gateways::SlackClient do
-  let(:post) { EsaFeeder::Entities::EsaPost.new(99999, 'path/to/post/post_title #tag', 'https://example.com/posts/99999') }
+  let(:post) { EsaFeeder::Entities::EsaPost.new(
+    99999,
+    'path/to/post/post_title #tag',
+    'https://example.com/posts/99999',
+    ['feed_mon', 'slack_hoge', 'feed_tue', 'slack_foo']) }
   let(:driver) { double('slack notifier') }
   let(:target) { described_class.new(driver) }
 
@@ -12,12 +16,13 @@ RSpec.describe EsaFeeder::Gateways::SlackClient do
   it '#notify_creation' do
     expect(driver)
       .to receive(:post)
-      .once
-      .with(attachments: [{
-          pretext: 'message',
-          title: 'path/to/post/post_title #tag',
-          title_link: 'https://example.com/posts/99999',
-          color: 'good' }])
+            .once
+            .with(attachments: [{
+                                  pretext: 'message',
+                                  title: 'path/to/post/post_title #tag',
+                                  title_link: 'https://example.com/posts/99999',
+                                  color: 'good'}],
+                  channel: ['hoge', 'foo'])
 
     target.notify_creation('message', post)
   end


### PR DESCRIPTION
タグでslack channelが指定されている場合に、slack通知する
複数指定されている場合にも対応している