### PR TITLE
システムタグを自動生成記事から削除する

### DIFF
--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -11,7 +11,19 @@ module EsaFeeder
         category ? "#{category}/#{name}" : name
       end
 
+      def user_tags
+        tags - system_tags
+      end
+
       private
+
+      def system_tags
+        feed_tags + slack_tags
+      end
+
+      def feed_tags
+        tags.select { |tag| tag =~ /^feed_/ }
+      end
 
       def slack_tags
         tags.select { |tag| tag =~ /^slack_/ }

--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -2,10 +2,14 @@
 
 module EsaFeeder
   module Entities
-    EsaPost = Struct.new(:number, :full_name, :url, :tags) do
+    EsaPost = Struct.new(:number, :category, :name, :url, :tags) do
       def slack_channels
         tags.select { |tag| tag =~ /^slack_/ }
             .map { |tag| tag.gsub(/^slack_/, '') }
+      end
+
+      def full_name
+        category ? "#{category}/#{name}" : name
       end
     end
   end

--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -4,12 +4,17 @@ module EsaFeeder
   module Entities
     EsaPost = Struct.new(:number, :category, :name, :url, :tags) do
       def slack_channels
-        tags.select { |tag| tag =~ /^slack_/ }
-            .map { |tag| tag.gsub(/^slack_/, '') }
+        slack_tags.map { |tag| tag.gsub(/^slack_/, '') }
       end
 
       def full_name
         category ? "#{category}/#{name}" : name
+      end
+
+      private
+
+      def slack_tags
+        tags.select { |tag| tag =~ /^slack_/ }
       end
     end
   end

--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -30,7 +30,8 @@ module EsaFeeder
       def to_post(raw)
         Entities::EsaPost.new(
           raw['number'],
-          raw['full_name'],
+          raw['category'],
+          raw['name'],
           raw['url'],
           raw['tags']
         )

--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -19,6 +19,13 @@ module EsaFeeder
         to_post(response.body)
       end
 
+      def update_post(post, user)
+        response = driver.update_post(
+          post.number, tags: post.tags, updated_by: user
+        )
+        to_post(response.body)
+      end
+
       private
 
       attr_reader :driver

--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -13,6 +13,9 @@ module EsaFeeder
         esa_port.find_templates(source_tag(time)).map do |template|
           post = esa_port.create_from_template(template, user)
           notifier_port&.notify_creation('新しい記事を作成しました', post)
+          # remove system tags from generated post
+          post.tags = post.user_tags
+          esa_port.update_post(post, user)
           { template.number => post.number }
         end
       end

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -56,4 +56,19 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
       it { expect(subject).to eq('path/to/post/test_post') }
     end
   end
+
+  describe '#user_tags' do
+    let(:post) { build(:esa_post, tags: tags) }
+    subject { post.user_tags }
+
+    context 'not contain system_tags' do
+      let(:tags) { %w[hoge fuga] }
+      it { expect(subject).to eq(%w[hoge fuga]) }
+    end
+
+    context 'contain system_tags' do
+      let(:tags) { %w[hoge feed_mon feed_fri slack_test fuga] }
+      it { expect(subject).to eq(%w[hoge fuga]) }
+    end
+  end
 end

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
     let(:post) do
       described_class.new(
         99_999,
-        'path/to/post/post_title #tag',
+        'path/to/post',
+        'post_title',
         'https://example.com/posts/99999',
         %w[feed_mon feed_tue]
       )
@@ -15,7 +16,8 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
 
     it 'can assign values' do
       expect(post.number).to eq(99_999)
-      expect(post.full_name).to eq('path/to/post/post_title #tag')
+      expect(post.category).to eq('path/to/post')
+      expect(post.name).to eq('post_title')
       expect(post.url).to eq('https://example.com/posts/99999')
       expect(post.tags).to eq(%w[feed_mon feed_tue])
     end
@@ -36,6 +38,22 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
       it 'return empty array' do
         expect(subject).to eq([])
       end
+    end
+  end
+
+  describe '#full_name' do
+    subject { post.full_name }
+
+    context 'in root' do
+      let(:post) { build(:esa_post, category: nil, name: 'test_post') }
+      it { expect(subject).to eq('test_post') }
+    end
+
+    context 'in category' do
+      let(:post) do
+        build(:esa_post, category: 'path/to/post', name: 'test_post')
+      end
+      it { expect(subject).to eq('path/to/post/test_post') }
     end
   end
 end

--- a/spec/factories/esa_post.rb
+++ b/spec/factories/esa_post.rb
@@ -3,13 +3,14 @@
 FactoryBot.define do
   factory :esa_post, class: EsaFeeder::Entities::EsaPost do
     sequence :number
-    full_name { "path/to/post/post_title_#{number} #feed_mon" }
+    category { 'path/to/post' }
+    name { "post_title_#{number}" }
     url { "https://example.com/posts/#{number}" }
     tags %w[tag]
 
     factory :esa_template do
       tags %w[tag feed_mon]
-      full_name { "templates/path/to/post/post_title_#{number} #feed_mon" }
+      category { 'templates/path/to/post' }
 
       trait :with_slack_tag do
         tags %w[tag feed_mon slack_hoge hoge_slack_fuga]

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -48,4 +48,25 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
       expect(subject).to eq(post)
     end
   end
+
+  describe '#update_post' do
+    let(:post) { build(:esa_post) }
+    let(:body) do
+      { 'number' => post.number,
+        'category' => post.category,
+        'name' => post.name,
+        'url' => post.url,
+        'tags' => post.tags }
+    end
+    let(:response) { double('response', body: body) }
+
+    subject { target.update_post(post, 'bot_user') }
+
+    it 'return updated post' do
+      allow(driver).to receive(:update_post)
+        .with(post.number, tags: post.tags, updated_by: 'bot_user')
+        .and_return(response)
+      expect(subject).to eq(post)
+    end
+  end
 end

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     let(:body) do
       { 'posts' => [
         'number' => template.number,
-        'full_name' => template.full_name,
+        'category' => template.category,
+        'name' => template.name,
         'url' => template.url,
         'tags' => template.tags
       ] }
@@ -31,7 +32,8 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     let(:post) { build(:esa_post) }
     let(:body) do
       { 'number' => post.number,
-        'full_name' => post.full_name,
+        'category' => post.category,
+        'name' => post.name,
         'url' => post.url,
         'tags' => post.tags }
     end

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe EsaFeeder::UseCases::Feed do
   let(:esa_client) { double('esa client') }
 
   let(:templates) { build_list(:esa_template, 2) }
-  let(:posts) { build_list(:esa_post, 2) }
+  let(:posts) do
+    build_list(:esa_post, 2, tags: %w[hoge feed_mon fuga slack_test])
+  end
 
   let(:expected) do
     [
@@ -22,12 +24,17 @@ RSpec.describe EsaFeeder::UseCases::Feed do
     expect(esa_client).to receive(:find_templates)
       .with('feed_mon').once
       .and_return(templates)
-    expect(esa_client).to receive(:create_from_template)
-      .with(templates[0], 'esa_bot').once
-      .and_return(posts[0])
-    expect(esa_client).to receive(:create_from_template)
-      .with(templates[1], 'esa_bot').once
-      .and_return(posts[1])
+    (0..1).each do |n|
+      expect(esa_client).to receive(:create_from_template)
+        .with(templates[n], 'esa_bot').once
+        .and_return(posts[n])
+      expect(esa_client).to receive(:update_post)
+        .with(
+          have_attributes(number: posts[n].number,
+                          tags: %w[hoge fuga]),
+          'esa_bot'
+        ).once
+    end
   end
 
   context 'notifier provided' do


### PR DESCRIPTION
### 目的

自動生成設定をタグで管理するが、自動生成された記事にこのタグが残ると邪魔になるため除去する。

### 実装

`template_post_id`を指定した記事作成では`tags`の指定が無視されるため、一度記事を作成してからタグを削除するupdateを行うようにした。

### テスト

`#test #feed_tue #feed_thu #feed_mon #feed_wed #feed_fri #slack_kokuyou_bot #slack_corocn_bot ` を指定した記事に対して自動作成を実行し、 `#test` だけの記事が生成されることを確認した。