### PR TITLE
#feed_wdayで平日に作る記事を指定できるようにした

### DIFF
--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -8,8 +8,8 @@ module EsaFeeder
         @notifier_port = notifier_port
       end
 
-      def call(tag, user)
-        find_templates(tag).map do |template|
+      def call(tags, user)
+        find_templates(tags).map do |template|
           post = esa_port.create_from_template(template, user)
           notifier_port&.notify_creation('新しい記事を作成しました', post)
           # remove system tags from generated post
@@ -23,8 +23,10 @@ module EsaFeeder
 
       attr_reader :esa_port, :notifier_port
 
-      def find_templates(tag)
-        esa_port.find_templates(tag) + esa_port.find_templates('feed_wday')
+      def find_templates(tags)
+        tags.map do |tag|
+          esa_port.find_templates(tag)
+        end.flatten
       end
     end
   end

--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -9,7 +9,7 @@ module EsaFeeder
       end
 
       def call(tag, user)
-        esa_port.find_templates(tag).map do |template|
+        find_templates(tag).map do |template|
           post = esa_port.create_from_template(template, user)
           notifier_port&.notify_creation('新しい記事を作成しました', post)
           # remove system tags from generated post
@@ -22,6 +22,10 @@ module EsaFeeder
       private
 
       attr_reader :esa_port, :notifier_port
+
+      def find_templates(tag)
+        esa_port.find_templates(tag) + esa_port.find_templates('feed_wday')
+      end
     end
   end
 end

--- a/lib/esa_feeder/use_cases/source_tag.rb
+++ b/lib/esa_feeder/use_cases/source_tag.rb
@@ -8,12 +8,20 @@ module EsaFeeder
       end
 
       def call
-        "feed_#{time.strftime('%a').downcase}"
+        [day_of_the_week_feed, weekday_feed].reject(&:nil?)
       end
 
       private
 
       attr_reader :time
+
+      def day_of_the_week_feed
+        "feed_#{time.strftime('%a').downcase}"
+      end
+
+      def weekday_feed
+        'feed_wday' unless [0, 6].include?(time.wday)
+      end
     end
   end
 end

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe EsaFeeder::UseCases::Feed do
   end
 
   subject do
-    described_class.new(esa_client, slack_client).call('feed_mon', 'esa_bot')
+    described_class.new(esa_client, slack_client)
+                   .call(%w[feed_mon feed_wday], 'esa_bot')
   end
 
   before do

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -4,16 +4,19 @@ require 'spec_helper'
 
 RSpec.describe EsaFeeder::UseCases::Feed do
   let(:esa_client) { double('esa client') }
-
-  let(:templates) { build_list(:esa_template, 2) }
+  let(:mon_templates) { build_list(:esa_template, 2) }
+  let(:wday_templates) { build_list(:esa_template, 2, tags: %w[tag feed_wday]) }
+  let(:templates) { mon_templates + wday_templates }
   let(:posts) do
-    build_list(:esa_post, 2, tags: %w[hoge feed_mon fuga slack_test])
+    build_list(:esa_post, 4, tags: %w[hoge feed_mon fuga slack_test])
   end
 
   let(:expected) do
     [
       { templates[0].number => posts[0].number },
-      { templates[1].number => posts[1].number }
+      { templates[1].number => posts[1].number },
+      { wday_templates[0].number => posts[2].number },
+      { wday_templates[1].number => posts[3].number }
     ]
   end
 
@@ -24,8 +27,13 @@ RSpec.describe EsaFeeder::UseCases::Feed do
   before do
     expect(esa_client).to receive(:find_templates)
       .with('feed_mon').once
-      .and_return(templates)
-    (0..1).each do |n|
+      .and_return(mon_templates)
+
+    expect(esa_client).to receive(:find_templates)
+      .with('feed_wday').once
+      .and_return(wday_templates)
+
+    (0..3).each do |n|
       expect(esa_client).to receive(:create_from_template)
         .with(templates[n], 'esa_bot').once
         .and_return(posts[n])

--- a/spec/use_cases/source_tag_spec.rb
+++ b/spec/use_cases/source_tag_spec.rb
@@ -9,7 +9,16 @@ RSpec.describe EsaFeeder::UseCases::SourceTag do
 
   let(:ref) { %w[sun mon tue wed thu fri sat] }
 
-  it 'check tag each day of the week' do
-    (0..6).map { |n| expect(tags[n]).to eq("feed_#{ref[n]}") }
+  it 'include tag each day of the week' do
+    (0..6).map { |n| expect(tags[n]).to include("feed_#{ref[n]}") }
+  end
+
+  it 'include tag #feed_wday on weekdays' do
+    (1..5).map { |n| expect(tags[n]).to include('feed_wday') }
+  end
+
+  it 'do not include tag #feed_wday on holiday' do
+    expect(tags[0]).not_to include('feed_wday')
+    expect(tags[6]).not_to include('feed_wday')
   end
 end


### PR DESCRIPTION
## :sparkles: 目的

* 日報は平日毎日作成するが、テンプレートに#feed_mon ~ #feed_friを追加する必要があったため
 
### :camera: スクリーンショット

![screen shot 2017-11-21 at 14 57 45](https://user-images.githubusercontent.com/23367170/33057084-5b147938-cecc-11e7-9851-7fa867fd1109.png)

## :muscle: 方針

* 平日に作成する記事のタグを#feed_wdayとした

## :wrench: 実装

* テンプレート検索時にタグを複数受け取れるようにした

## :white_check_mark: テスト

 * misoca-sandbox.esa.ioにて動作を確認した