### PR TITLE
祝日に#feed_wdayタグがついた記事を作成しないようにした

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
+    holiday_japan (1.2.5)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
@@ -77,6 +78,7 @@ DEPENDENCIES
   esa
   esa_feeder!
   factory_bot
+  holiday_japan
   pry
   rake (~> 10.0)
   rspec (~> 3.0)
@@ -85,4 +87,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/esa_feeder.gemspec
+++ b/esa_feeder.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'holiday_japan'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/esa_feeder/use_cases/source_tag.rb
+++ b/lib/esa_feeder/use_cases/source_tag.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'holiday_japan'
+
 module EsaFeeder
   module UseCases
     class SourceTag
@@ -20,7 +22,11 @@ module EsaFeeder
       end
 
       def weekday_feed
-        'feed_wday' unless [0, 6].include?(time.wday)
+        'feed_wday' if (1..5).cover?(time.wday) && !holiday?
+      end
+
+      def holiday?
+        HolidayJapan.check(time.to_date)
       end
     end
   end

--- a/spec/use_cases/source_tag_spec.rb
+++ b/spec/use_cases/source_tag_spec.rb
@@ -4,8 +4,9 @@ require 'spec_helper'
 
 RSpec.describe EsaFeeder::UseCases::SourceTag do
   let(:tags) do
-    (0..6).map { |n| described_class.new(Time.local(2017, 1, 1 + n)).call }
+    (0..6).map { |n| described_class.new(Time.local(2017, 4, 2 + n)).call }
   end
+  let(:holiday_tags) { described_class.new(Time.local(2017, 11, 23)).call }
 
   let(:ref) { %w[sun mon tue wed thu fri sat] }
 
@@ -17,8 +18,13 @@ RSpec.describe EsaFeeder::UseCases::SourceTag do
     (1..5).map { |n| expect(tags[n]).to include('feed_wday') }
   end
 
-  it 'do not include tag #feed_wday on holiday' do
+  it 'do not include tag #feed_wday on weekend' do
     expect(tags[0]).not_to include('feed_wday')
     expect(tags[6]).not_to include('feed_wday')
+  end
+
+  it 'do not include tag #feed_wday on public holiday' do
+    expect(holiday_tags).not_to include('feed_wday')
+    expect(holiday_tags).to include('feed_thu')
   end
 end


### PR DESCRIPTION
## :sparkles: 目的

* 日報など平日に作成してほしい記事を祝日に作成されないようにしたいため

## :muscle: 方針

* その日が祝日かどうかを判定して#feed_wdayタグのついた記事を作成する/しないを分岐した

## :wrench: 実装

https://github.com/masa16/holiday_japan gemを使って祝日かどうかを判定した

## :white_check_mark: テスト

 * specにて祝日の記事作成対象に#feed_wdayタグが含まれないことを確認した