### PR TITLE
同じテンプレートからユーザごとにポストを作る

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,13 @@
 Style/Documentation:
   Enabled: false
 
+Metrics/LineLength:
+  Max: 128
+
+Metrics/AbcSize:
+  Max: 20
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+  ExcludedMethods: Struct.new

--- a/lib/esa_feeder.rb
+++ b/lib/esa_feeder.rb
@@ -12,8 +12,7 @@ require 'esa_feeder/gateways/slack_client'
 module EsaFeeder
   class << self
     def feed
-      UseCases::Feed.new(esa_client, slack_client)
-                    .call(UseCases::SourceTag.new.call, 'esa_bot')
+      UseCases::Feed.new(esa_client, slack_client).call(UseCases::SourceTag.new.call)
     end
 
     private

--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -15,10 +15,18 @@ module EsaFeeder
         tags - system_tags
       end
 
+      def feed_users
+        if me_tags.empty?
+          ['esa_bot']
+        else
+          me_tags.map { |tag| tag.gsub(/^me_/, '') }
+        end
+      end
+
       private
 
       def system_tags
-        feed_tags + slack_tags
+        feed_tags + slack_tags + me_tags
       end
 
       def feed_tags
@@ -27,6 +35,10 @@ module EsaFeeder
 
       def slack_tags
         tags.select { |tag| tag =~ /^slack_/ }
+      end
+
+      def me_tags
+        tags.select { |tag| tag =~ /^me_/ }
       end
     end
   end

--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -8,15 +8,17 @@ module EsaFeeder
         @notifier_port = notifier_port
       end
 
-      def call(tags, user)
+      def call(tags)
         find_templates(tags).map do |template|
-          post = esa_port.create_from_template(template, user)
-          notifier_port&.notify_creation('新しい記事を作成しました', post)
-          # remove system tags from generated post
-          post.tags = post.user_tags
-          esa_port.update_post(post, user)
-          { template.number => post.number }
-        end
+          template.feed_users.map do |feed_user|
+            post = esa_port.create_from_template(template, feed_user)
+            notifier_port&.notify_creation('新しい記事を作成しました', post)
+            # remove system tags from generated post
+            post.tags = post.user_tags
+            esa_port.update_post(post, feed_user)
+            { template.number => post.number }
+          end
+        end.flatten
       end
 
       private

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -71,4 +71,19 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
       it { expect(subject).to eq(%w[hoge fuga]) }
     end
   end
+
+  describe '#feed_users' do
+    let(:post) { build(:esa_template, tags: tags) }
+    subject { post.feed_users }
+
+    context 'not contain me_tags' do
+      let(:tags) { %w[hoge fuga] }
+      it { expect(subject).to eq(%w[esa_bot]) }
+    end
+
+    context 'contain me_tags' do
+      let(:tags) { %w[hoge fuga me_test] }
+      it { expect(subject).to eq(%w[test]) }
+    end
+  end
 end

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -4,61 +4,76 @@ require 'spec_helper'
 
 RSpec.describe EsaFeeder::UseCases::Feed do
   let(:esa_client) { double('esa client') }
-  let(:mon_templates) { build_list(:esa_template, 2) }
-  let(:wday_templates) { build_list(:esa_template, 2, tags: %w[tag feed_wday]) }
-  let(:templates) { mon_templates + wday_templates }
-  let(:posts) do
-    build_list(:esa_post, 4, tags: %w[hoge feed_mon fuga slack_test])
+  let(:feed_users) { %w[esa_bot] }
+
+  subject do
+    described_class.new(esa_client, slack_client).call([tag])
   end
 
   let(:expected) do
     [
       { templates[0].number => posts[0].number },
-      { templates[1].number => posts[1].number },
-      { wday_templates[0].number => posts[2].number },
-      { wday_templates[1].number => posts[3].number }
+      { templates[1].number => posts[1].number }
     ]
   end
 
-  subject do
-    described_class.new(esa_client, slack_client)
-                   .call(%w[feed_mon feed_wday], 'esa_bot')
-  end
-
-  before do
-    expect(esa_client).to receive(:find_templates)
-      .with('feed_mon').once
-      .and_return(mon_templates)
-
-    expect(esa_client).to receive(:find_templates)
-      .with('feed_wday').once
-      .and_return(wday_templates)
-
-    (0..3).each do |n|
+  shared_context 'mock esa api' do |template_no, post_no, feed_user|
+    before do
       expect(esa_client).to receive(:create_from_template)
-        .with(templates[n], 'esa_bot').once
-        .and_return(posts[n])
+        .with(templates[template_no], feed_user).once
+        .and_return(posts[post_no])
       expect(esa_client).to receive(:update_post)
         .with(
-          have_attributes(number: posts[n].number,
-                          tags: %w[hoge fuga]),
-          'esa_bot'
+          have_attributes(number: posts[post_no].number,
+                          tags: %w[hoge fuga]), feed_user
         ).once
     end
   end
 
-  context 'notifier provided' do
-    let(:slack_client) { double('slack client') }
-    it 'create posts and notify' do
-      expect(slack_client).to receive(:notify_creation).exactly(templates.count)
-      expect(subject).to eq(expected)
+  shared_examples 'create post from templates' do
+    before do
+      expect(esa_client).to receive(:find_templates)
+        .with(tag).once
+        .and_return(templates)
+    end
+
+    context 'notifier provided' do
+      let(:slack_client) { double('slack client') }
+      it 'create posts and notify' do
+        expect(slack_client).to receive(:notify_creation).exactly(expected.length)
+        expect(subject).to eq(expected)
+      end
+    end
+
+    context 'notifier not provided' do
+      let(:slack_client) { nil }
+      it 'create posts' do
+        expect(subject).to eq(expected)
+      end
     end
   end
 
-  context 'notifier not provided' do
-    let(:slack_client) { nil }
-    it 'create posts' do
-      expect(subject).to eq(expected)
+  context 'mon_templates' do
+    let(:templates) { build_list(:esa_template, 2) }
+    let(:tag) { 'feed_mon' }
+    let(:posts) do
+      build_list(:esa_post, 2, tags: %w[hoge feed_mon fuga slack_test])
     end
+
+    include_context 'mock esa api', 0, 0, 'esa_bot'
+    include_context 'mock esa api', 1, 1, 'esa_bot'
+    it_behaves_like 'create post from templates'
+  end
+
+  context 'wday_templates' do
+    let(:templates) { build_list(:esa_template, 2, tags: %w[tag feed_wday]) }
+    let(:tag) { 'feed_wday' }
+    let(:posts) do
+      build_list(:esa_post, 2, tags: %w[hoge feed_wday fuga slack_test])
+    end
+
+    include_context 'mock esa api', 0, 0, 'esa_bot'
+    include_context 'mock esa api', 1, 1, 'esa_bot'
+    it_behaves_like 'create post from templates'
   end
 end

--- a/spec/use_cases/esa_feeder_spec.rb
+++ b/spec/use_cases/esa_feeder_spec.rb
@@ -76,4 +76,24 @@ RSpec.describe EsaFeeder::UseCases::Feed do
     include_context 'mock esa api', 1, 1, 'esa_bot'
     it_behaves_like 'create post from templates'
   end
+
+  context 'me_templates' do
+    let(:templates) { build_list(:esa_template, 1, tags: %w[tag feed_wday me_hoge me_fuga]) }
+    let(:tag) { 'feed_wday' }
+    let(:feed_users) { %w[hoge fuga] }
+    let(:posts) do
+      build_list(:esa_post, 2, tags: %w[hoge feed_wday fuga me_hoge me_fuga])
+    end
+
+    let(:expected) do
+      [
+        { templates[0].number => posts[0].number },
+        { templates[0].number => posts[1].number }
+      ]
+    end
+
+    include_context 'mock esa api', 0, 0, 'hoge'
+    include_context 'mock esa api', 0, 1, 'fuga'
+    it_behaves_like 'create post from templates'
+  end
 end


### PR DESCRIPTION
## :sparkles: 目的

* テンプレートの%{me}を特定のユーザ名で置き換えることができないため、ユーザごとにテンプレートを作る必要があったため

## :muscle: 方針

* 1つテンプレートにme_から始まるタグを付与してユーザごとにポストを作成できるようにした

## :white_check_mark: テスト

 * me_から始まるタグが複数ある場合にユーザごとに記事が作成されることを確認した