### PR TITLE
ユーザ個人のテンプレートからポストを作成できるようにした

### DIFF
--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -16,10 +16,12 @@ module EsaFeeder
       end
 
       def feed_users
-        if me_tags.empty?
-          ['esa_bot']
-        else
+        if private_template?
+          [category_user]
+        elsif me_tags_present?
           me_tags.map { |tag| tag.gsub(/^me_/, '') }
+        else
+          ['esa_bot']
         end
       end
 
@@ -37,8 +39,20 @@ module EsaFeeder
         tags.select { |tag| tag =~ /^slack_/ }
       end
 
+      def me_tags_present?
+        !me_tags.empty?
+      end
+
       def me_tags
         tags.select { |tag| tag =~ /^me_/ }
+      end
+
+      def private_template?
+        !category_user.nil?
+      end
+
+      def category_user
+        category[%r{Users/(\w+)/templates}, 1]
       end
     end
   end

--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -10,7 +10,7 @@ module EsaFeeder
       end
 
       def find_templates(tag)
-        response = driver.posts(q: "in:templates tag:#{tag}")
+        response = driver.posts(q: "category:templates tag:#{tag}")
         to_posts(response.body)
       end
 

--- a/spec/entities/esa_post_spec.rb
+++ b/spec/entities/esa_post_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
   end
 
   describe '#feed_users' do
-    let(:post) { build(:esa_template, tags: tags) }
+    let(:category) { 'templates/path/to/post' }
+    let(:post) { build(:esa_template, category: category, tags: tags) }
     subject { post.feed_users }
 
     context 'not contain me_tags' do
@@ -84,6 +85,12 @@ RSpec.describe EsaFeeder::Entities::EsaPost do
     context 'contain me_tags' do
       let(:tags) { %w[hoge fuga me_test] }
       it { expect(subject).to eq(%w[test]) }
+    end
+
+    context 'user private templates' do
+      let(:tags) { %w[hoge fuga me_test] }
+      let(:category) { 'Users/piyo/templates/path/to/post' }
+      it { expect(subject).to eq(%w[piyo]) }
     end
   end
 end

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     subject { target.find_templates('test_tag') }
 
     it 'return templates' do
-      allow(driver).to receive(:posts).with(q: 'in:templates tag:test_tag')
+      allow(driver).to receive(:posts).with(q: 'category:templates tag:test_tag')
                                       .and_return(response)
       expect(subject).to eq([template])
     end


### PR DESCRIPTION
## :sparkles: 目的

* templatesカテゴリ内に個人用テンプレートを作成すると、手動作成時にテンプレートがわからなくなるので、これを解消したいため

## :muscle: 方針

* これまでテンプレート検索を `templates`カテゴリ内のテンプレートのみを検索していたところを、カテゴリ名に `templates`を含むカテゴリ全てから検索するようにする

## :wrench: 実装

* サーチクエリを `in:templates`から `category:templates`に修正する

## :white_check_mark: テスト

* 個人テンプレートからポストを自動作成できることを確認した