### PR TITLE
テンプレート検索時にアーカイブ済のテンプレートを除くようにした

### DIFF
--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -10,7 +10,7 @@ module EsaFeeder
       end
 
       def find_templates(tag)
-        response = driver.posts(q: "category:templates tag:#{tag}")
+        response = driver.posts(q: "category:templates -in:Archived tag:#{tag}")
         to_posts(response.body)
       end
 

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     subject { target.find_templates('test_tag') }
 
     it 'return templates' do
-      allow(driver).to receive(:posts).with(q: 'category:templates tag:test_tag')
+      allow(driver).to receive(:posts).with(q: 'category:templates -in:Archived tag:test_tag')
                                       .and_return(response)
       expect(subject).to eq([template])
     end


### PR DESCRIPTION
## :sparkles: 目的

* テンプレート検索時にアーカイブ済のテンプレートも検索結果に入っていたため

## :muscle: 方針

* esaの検索クエリを修正して `Archived`以下の検索を除くようにした

## :white_check_mark: テスト

* アーカイブ済のテンプレートからポストが自動作成されないことを確認した