### PR TITLE
Slack通知に失敗しても記事作成処理を続行するようにした

### DIFF
--- a/lib/esa_feeder/gateways/slack_client.rb
+++ b/lib/esa_feeder/gateways/slack_client.rb
@@ -17,6 +17,9 @@ module EsaFeeder
           color: 'good'
         }],
                     channel: post.slack_channels
+      rescue Slack::Notifier::APIError => e
+        puts e.inspect
+        nil
       end
 
       private


### PR DESCRIPTION
## :sparkles: 目的

`#slack_xxx`タグがついた記事を自動作成する際に、`xxx`チャンネルが存在しない場合にエラーで止まってしまう。
これを解決する。

## :muscle: 方針

エラー原因を標準出力に吐いて、記事作成処理を続行させる。

## :white_check_mark: テスト

テンプレートのタグに存在しないチャンネル名を指定した状態で記事作成処理を走らせたときに、Slack通知に失敗した原因を出力した後に記事作成処理が続行することを確認した。