### PR TITLE
Continue process when exception raised

### DIFF
--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -11,12 +11,7 @@ module EsaFeeder
       def call(tags)
         find_templates(tags).map do |template|
           template.feed_users.map do |feed_user|
-            post = esa_port.create_from_template(template, feed_user)
-            notifier_port&.notify_creation('新しい記事を作成しました', post)
-            # remove system tags from generated post
-            post.tags = post.user_tags
-            esa_port.update_post(post, feed_user)
-            { template.number => post.number }
+            feed_post(template, feed_user)
           end
         end.flatten
       end
@@ -29,6 +24,15 @@ module EsaFeeder
         tags.map do |tag|
           esa_port.find_templates(tag)
         end.flatten
+      end
+
+      def feed_post(template, feed_user)
+        post = esa_port.create_from_template(template, feed_user)
+        notifier_port&.notify_creation('新しい記事を作成しました', post)
+        # remove system tags from generated post
+        post.tags = post.user_tags
+        esa_port.update_post(post, feed_user)
+        { template.number => post.number }
       end
     end
   end

--- a/lib/esa_feeder/use_cases/feed.rb
+++ b/lib/esa_feeder/use_cases/feed.rb
@@ -33,6 +33,10 @@ module EsaFeeder
         post.tags = post.user_tags
         esa_port.update_post(post, feed_user)
         { template.number => post.number }
+      rescue StandardError => e
+        # continue other processing
+        puts e.inspect
+        {}
       end
     end
   end


### PR DESCRIPTION
## :sparkles: 目的

一部不正なpostがあり、nil呼び出しが発生するケースがあった。

```
Apr 03 17:00:52 esa-feeder app/scheduler.5110:  E, [2019-04-04T09:00:52.275165 #4] ERROR -- : private method `select' called for nil:NilClass (NoMethodError) 
Apr 03 17:00:52 esa-feeder app/scheduler.5110:  /app/lib/esa_feeder/entities/esa_post.rb:39:in `slack_tags' 
Apr 03 17:00:52 esa-feeder app/scheduler.5110:  /app/lib/esa_feeder/entities/esa_post.rb:7:in `slack_channels' 
```

記事作成途中で例外が出た場合、以降のテンプレートからの記事が作られない。
これは望ましくないため、例外が出た場合でも以降のテンプレートについての処理を継続するようにする。

なお、上記例外が出ないよう実装を修正するべきだが、これは別PRで行う。

## :wrench: 実装

テンプレートごとのfeed処理について、StandardErrorを拾って例外情報を出力した上で処理を継続するようにした。
なおRubocopのMethodLengthに引っかかったので、メソッドを切り出すリファクタも行っている。

## :white_check_mark: テスト

specが通っている。
例外処理の追加なので、あとは実際に動けば問題ないはず。