### PR TITLE
handle error when user does not exists

### DIFF
--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -5,6 +5,9 @@ require 'esa'
 module EsaFeeder
   module Gateways
     class EsaClient
+      class PostCreateError < StandardError; end
+      class PostUpdateError < StandardError; end
+
       def initialize(driver)
         @driver = driver
       end
@@ -16,6 +19,8 @@ module EsaFeeder
 
       def create_from_template(post, user)
         response = driver.create_post(template_post_id: post.number, user: user)
+        # error happen when user does not exists
+        raise PostCreateError, response.to_s if response.error
         to_post(response.body)
       end
 
@@ -23,6 +28,8 @@ module EsaFeeder
         response = driver.update_post(
           post.number, tags: post.tags, updated_by: user
         )
+        # error happen when user does not exists
+        raise PostUpdateError, response.to_s if response.error
         to_post(response.body)
       end
 

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -37,15 +37,26 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
         'url' => post.url,
         'tags' => post.tags }
     end
-    let(:response) { double('response', body: body) }
+    let(:error) { nil }
+    let(:response) { double('response', body: body, error: error) }
 
-    subject { target.create_from_template(template, 'bot_user') }
-
-    it 'return created post' do
+    before do
       allow(driver).to receive(:create_post)
         .with(template_post_id: template.number, user: 'bot_user')
         .and_return(response)
+    end
+    subject { target.create_from_template(template, 'bot_user') }
+
+    it 'return created post' do
       expect(subject).to eq(post)
+    end
+
+    context 'api returns error' do
+      let(:error) { 'some errors' }
+
+      it 'raise exeption' do
+        expect { subject }.to raise_exception(EsaFeeder::Gateways::EsaClient::PostCreateError)
+      end
     end
   end
 
@@ -58,15 +69,27 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
         'url' => post.url,
         'tags' => post.tags }
     end
-    let(:response) { double('response', body: body) }
+    let(:error) { nil }
+    let(:response) { double('response', body: body, error: error) }
+
+    before do
+      allow(driver).to receive(:update_post)
+        .with(post.number, tags: post.tags, updated_by: 'bot_user')
+        .and_return(response)
+    end
 
     subject { target.update_post(post, 'bot_user') }
 
     it 'return updated post' do
-      allow(driver).to receive(:update_post)
-        .with(post.number, tags: post.tags, updated_by: 'bot_user')
-        .and_return(response)
       expect(subject).to eq(post)
+    end
+
+    context 'api returns error' do
+      let(:error) { 'some error' }
+
+      it 'raise exeption' do
+        expect { subject }.to raise_exception(EsaFeeder::Gateways::EsaClient::PostUpdateError)
+      end
     end
   end
 end


### PR DESCRIPTION
## :sparkles: 目的

記事を作る際、作成ユーザがいないとAPIがエラーレスポンスを返し、空の記事で処理を続行してエラーが発生していた。
これを修正する。

## :muscle: 方針

Esa API Clientでのエラー処理が漏れていたため、APIがエラーを返した場合は例外を投げるようにする。

## :white_check_mark: テスト

specは追加した。
#46 と合わせて、処理が続行されるようになるはず。
既存処理に影響はないため、実地で動作確認すれば良いと思う。