### PR TITLE
errorの入ってくる場所を間違えていたので修正

### DIFF
--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -20,7 +20,7 @@ module EsaFeeder
       def create_from_template(post, user)
         response = driver.create_post(template_post_id: post.number, user: user)
         # error happen when user does not exists
-        raise PostCreateError, response.to_s if response.error
+        raise PostCreateError, response.to_s if response.body['error']
         to_post(response.body)
       end
 
@@ -29,7 +29,7 @@ module EsaFeeder
           post.number, tags: post.tags, updated_by: user
         )
         # error happen when user does not exists
-        raise PostUpdateError, response.to_s if response.error
+        raise PostUpdateError, response.to_s if response.body['error']
         to_post(response.body)
       end
 

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
         'url' => post.url,
         'tags' => post.tags }
     end
-    let(:error) { nil }
-    let(:response) { double('response', body: body, error: error) }
+    let(:response) { double('response', body: body) }
 
     before do
       allow(driver).to receive(:create_post)
@@ -52,7 +51,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     end
 
     context 'api returns error' do
-      let(:error) { 'some errors' }
+      let(:body) { { 'error' => 'some errors' } }
 
       it 'raise exeption' do
         expect { subject }.to raise_exception(EsaFeeder::Gateways::EsaClient::PostCreateError)
@@ -69,8 +68,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
         'url' => post.url,
         'tags' => post.tags }
     end
-    let(:error) { nil }
-    let(:response) { double('response', body: body, error: error) }
+    let(:response) { double('response', body: body) }
 
     before do
       allow(driver).to receive(:update_post)
@@ -85,7 +83,7 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     end
 
     context 'api returns error' do
-      let(:error) { 'some error' }
+      let(:body) { { 'error' => 'some errors' } }
 
       it 'raise exeption' do
         expect { subject }.to raise_exception(EsaFeeder::Gateways::EsaClient::PostUpdateError)


### PR DESCRIPTION
## :sparkles: 目的

No Method Errorが発生するようになってしまったため直す。

> #<NoMethodError: undefined method `error' for #<Esa::Response:0x00005580ec6e0c68>>

## :muscle: 方針

responseに直接ではなく、body内に入っていたので、正しい箇所から取るようにする。

## :white_check_mark: テスト

 * rspecが通っている
