### PR TITLE
Search also "Templates" category

### DIFF
--- a/lib/esa_feeder/entities/esa_post.rb
+++ b/lib/esa_feeder/entities/esa_post.rb
@@ -52,7 +52,7 @@ module EsaFeeder
       end
 
       def category_user
-        category[%r{Users/(\w+)/templates}, 1]
+        category[%r{Users/(\w+)/(t|T)emplates}, 1]
       end
     end
   end

--- a/lib/esa_feeder/gateways/esa_client.rb
+++ b/lib/esa_feeder/gateways/esa_client.rb
@@ -13,7 +13,7 @@ module EsaFeeder
       end
 
       def find_templates(tag)
-        response = driver.posts(q: "category:templates -in:Archived tag:#{tag}")
+        response = driver.posts(q: "category:templates -in:Archived tag:#{tag} OR category:Templates -in:Archived tag:#{tag}")
         to_posts(response.body)
       end
 

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe EsaFeeder::Gateways::EsaClient do
     subject { target.find_templates('test_tag') }
 
     it 'return templates' do
-      allow(driver).to receive(:posts).with(q: 'category:templates -in:Archived tag:test_tag')
-                                      .and_return(response)
+      query = 'category:templates -in:Archived tag:test_tag OR category:Templates -in:Archived tag:test_tag'
+
+      allow(driver).to receive(:posts).with(q: query).and_return(response)
       expect(subject).to eq([template])
     end
   end


### PR DESCRIPTION
## :sparkles: 目的

* esa は検索時に大文字小文字を区別するようで、`category:templates` だと `Templates` カテゴリの記事はマッチしませんでした
    * ちなみに esa は `templates` カテゴリでも `Templates` カテゴリでもどちらもテンプレートとして認識する
* そのため、`Templates` カテゴリの記事も検索対象に入れるようにします

具体的には以下の検索クエリの部分。

https://github.com/standfirm/esa_feeder/blob/d6483403330e230936f29cb35e728397be3963fc/lib/esa_feeder/gateways/esa_client.rb#L16

## :muscle: 方針

* 二回 API リクエストを投げたくないので、検索クエリでなんとかしました
* ちなみに esa の検索では OR 検索と AND 検索を併用したときに、`category:templates OR category:Templates -in:Archived tag:feed_wday` ではダメで、`category:templates -in:Archived tag:feed_wday OR category:Templates -in:Archived tag:feed_wday` のように `OR` を使った場合は重複してクエリを書かないとダメなようでした

## :white_check_mark: テスト

 * rspec, rubocop が通っている
 * `templates` カテゴリと `Templates` カテゴリでそれぞれテンプレートを作ってどちらも記事が作られることを確認

**テンプレート**

![image](https://user-images.githubusercontent.com/10208211/58624684-ce44b900-830b-11e9-8de7-47ebeb05ade4.png)

![image](https://user-images.githubusercontent.com/10208211/58624702-d69cf400-830b-11e9-8c33-1588770e5880.png)

↓

**作成された記事**

![image](https://user-images.githubusercontent.com/10208211/58624762-f46a5900-830b-11e9-8eb9-ba49f7b8cbb8.png)
