### PR TITLE
Set "required: false" for $SLACK_WEBHOOK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
       "description": "esa.io personal access token. Get from https://your_team.esa.io/user/applications"
     },
     "SLACK_WEBHOOK_URL": {
-      "description": "Slack incoming webhook url. Get from https://your_team.slack.com/apps/manage/custom-integrations. If this variable is empty, then notification is disabled."
+      "description": "Slack incoming webhook url. Get from https://your_team.slack.com/apps/manage/custom-integrations. If this variable is empty, then notification is disabled.",
+      "required": false
     },
     "LANG": {
       "description": "Language Code",


### PR DESCRIPTION
## :sparkles: 目的

* Heroku の Deploy ボタンからデプロイするときに環境変数 `SLACK_WEBHOOK_URL` が必須になっていたので、optional にしたい

    <img width="849" alt="貼り付けた画像_2019_05_30_19_29" src="https://user-images.githubusercontent.com/10208211/58627049-3944be80-8311-11e9-94f8-08fd22a53477.png">

## :muscle: 方針

* `app.json` のスキーマのドキュメントによると、`required` パラメータがデフォルトで true なのでこれを明示的に false にしてやれば良いとのこと

    > * `required`: A boolean indicating whether the given value is required for the app to function (default: `true`).
    >
    > https://devcenter.heroku.com/articles/app-json-schema#env

## :white_check_mark: テスト

* [トピックブランチの README](https://github.com/tsub/esa_feeder/blob/df3b92512a209d5932cdfb1be736a4cd2f5819f8/README.md) から Deploy to Heroku ボタンをクリックし、`$SLACK_WEBHOOK_URL` の `Required` ラベルが消えていることを確認

    <img width="754" alt="貼り付けた画像_2019_05_30_19_29" src="https://user-images.githubusercontent.com/10208211/58627065-419cf980-8311-11e9-995e-e5049cee88a8.png">