### PR TITLE
fix circleci no build step error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  ruby_test:
+  build:
     working_directory: ~/esa_feeder
     docker:
       - image: circleci/ruby:2.5.3
@@ -12,8 +12,3 @@ jobs:
       - run:
           name: run test
           command: bundle exec rspec spec/
-workflows:
-  version: 2
-  test:
-    jobs:
-      - ruby_test


### PR DESCRIPTION
## :sparkles: 目的

なぜかmasterでリビルドしたら以下のようなエラーが出たので修正する。

```
Build-agent version 1.0.11727-b0960fc9 (2019-05-23T02:12:54+0000)
Configuration errors: 1 error occurred:

* Cannot find a job named `build` to run in the `jobs:` section of your configuration file.
If you expected a workflow to run, check your config contains a top-level key called 'workflows:'
```

## :muscle: 方針

workflowsキーがあるのに認識されていないのが謎だが、そもそもworkflows設定はまともに使っていないため消して、自動で認識されるbuildステップでビルドさせるようにする。

## :white_check_mark: テスト

circleciが通っている